### PR TITLE
Change Hardhat default network to `localfhenix`

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -41,7 +41,7 @@ if (!keys) {
 
 const config: HardhatUserConfig = {
   solidity: "0.8.25",
-  defaultNetwork: "hardhat",
+  defaultNetwork: "localfhenix",
   networks: {
     testnet: testnetConfig,
   },


### PR DESCRIPTION
Without this it seems to use the remote testnet and the commands in the README doesn't really work.
In particular `npx hardhat deploy` doesn't deploy on the local testnet (you can verify it by looking at the docker container logs) and then `pnpm task:getCount ` fails because it doesn't find the directory the `deployments` (perhaps you didn't noticed because that directory is gitignored, try cloning the project from scratch).